### PR TITLE
Add a failing integration test.

### DIFF
--- a/integration_tests/txinfo_msgtransfer.py
+++ b/integration_tests/txinfo_msgtransfer.py
@@ -1,0 +1,9 @@
+from terra_sdk.client.lcd import LCDClient
+
+
+if __name__ == "__main__":
+    client = LCDClient(url="https://lcd.terra.dev", chain_id="columbus-5")
+
+    client.tx.tx_info(
+        "D22FC6EB287D9F099DD8EBADAAC5D9A0F6AA9D6B87F4A35A3FACEF4182706A16"
+    )


### PR DESCRIPTION
The test raises an exception when it encounters a message of type `cosmos-sdk/MsgTransfer`. See issue #62.