### PR TITLE
Store coin type in MnemonicKey

### DIFF
--- a/terra_sdk/key/mnemonic.py
+++ b/terra_sdk/key/mnemonic.py
@@ -69,5 +69,6 @@ class MnemonicKey(RawKey):
 
         super().__init__(child.PrivateKey())
         self.mnemonic = mnemonic
+        self.coin_type = coin_type
         self.account = account
         self.index = index


### PR DESCRIPTION
`MnemonicKey.hd_path` (added in terra-money/terra.py@c80720279c62415acc8fac8bd6b39c14d4f8e21d) requires `self.coin_type` to be set, otherwise it fails with `AttributeError`.