### PR TITLE
fix datetime json serialization

### DIFF
--- a/terra_sdk/util/converter.py
+++ b/terra_sdk/util/converter.py
@@ -5,5 +5,5 @@ def to_isoformat(dt: datetime) -> str:
     return (
         dt.isoformat(timespec="milliseconds")
         .replace("+00:00", "Z")
-        .replace("000Z", "Z")
+        .replace(".000Z", "Z")
     )

--- a/terra_sdk/util/json.py
+++ b/terra_sdk/util/json.py
@@ -16,6 +16,8 @@ def to_data(x: Any) -> Any:
         return [to_data(g) for g in x]
     if isinstance(x, dict):
         return dict_to_data(x)
+    if isinstance(x, datetime):
+        return to_isoformat(x)
     return x
 
 


### PR DESCRIPTION
I stumbled upon another serialization error. This
```
from terra_sdk.client.lcd import LCDClient
from terra_sdk.util.hash import hash_amino

terra = LCDClient(chain_id="columbus-5", url="https://lcd.terra.dev")
bi = terra.tendermint.block_info(7309740)
info = terra.tx.tx_info(hash_amino(bi["block"]["data"]["txs"][143]))
info.tx.body.messages[0].to_json()
```
raises
```
TypeError: Object of type datetime is not JSON serializable
at terra_sdk/util/json.py:58
```
The fix is below but I'm not sure about the general solution (turning a datetime into a str as `to_data` seems to be used on many places)

Also, I believe that the `terra_sdk.util.converter.to_isoformat()` has a small bug 
I was not able to parse it back with `dateutils` unlet the "dot" is removed:
```
dateutil.parser.isoparse(json.loads(info.tx.body.messages[0].to_json())["allowance"]["expiration"])
```