### PR TITLE
fix CompactBitArray deserialization: add base64 decode

### DIFF
--- a/terra_sdk/core/compact_bit_array.py
+++ b/terra_sdk/core/compact_bit_array.py
@@ -1,5 +1,6 @@
 """CompactBitArray types related to multisig."""
 from __future__ import annotations
+import base64
 
 import math
 
@@ -20,7 +21,9 @@ class CompactBitArray(JSONSerializable):
 
     @classmethod
     def from_data(cls, data: dict) -> CompactBitArray:
-        return cls(data["extra_bits_stored"], bytearray(data["elems"]))
+        return cls(
+            data["extra_bits_stored"], bytearray(base64.b64decode(data["elems"]))
+        )
 
     @classmethod
     def from_proto(cls, proto: CompactBitArray_pb) -> CompactBitArray:


### PR DESCRIPTION
I believe there's a missing base64 decode in the `CompactBitArray.from_data()` as it crashes for:
```
from terra_sdk.client.lcd import LCDClient
from terra_sdk.util.hash import hash_amino

terra = LCDClient(chain_id="columbus-5", url="https://lcd.terra.dev")
bi = terra.tendermint.block_info(7311243)
info = terra.tx.tx_info(hash_amino(bi["block"]["data"]["txs"][19]))
```
```
File .../terra.py/terra_sdk/core/compact_bit_array.py:24, in CompactBitArray.from_data(cls, data)
     22 @classmethod
     23 def from_data(cls, data: dict) -> CompactBitArray:
---> 24     return cls(data["extra_bits_stored"], bytearray(data["elems"]))

TypeError: string argument without an encoding

```