### PR TITLE
fix SimplePublicKey | ValConsPubKey | ModeInfoSingle | JSONSerializab…

### DIFF
--- a/integration_tests/public_key&txinfo.py
+++ b/integration_tests/public_key&txinfo.py
@@ -1,0 +1,108 @@
+from terra_sdk.client.lcd import AsyncLCDClient
+from terra_sdk.core import Coins
+from terra_sdk.core.public_key import SimplePublicKey, ValConsPubKey
+from terra_sdk.core.tx import TxInfo
+from terra_sdk.key.key import Key
+from terra_sdk.util import hash
+import requests, asyncio
+
+light_clinet_address = 'https://bombay-lcd.terra.dev'
+chain_id = 'bombay-12'
+gas_prices = requests.get('https://bombay-fcd.terra.dev/v1/txs/gas_prices').json()
+terra = AsyncLCDClient(chain_id=chain_id,
+                       url=light_clinet_address,
+                       gas_prices=Coins(uusd=gas_prices['uusd']),
+                       gas_adjustment=1.2)
+
+
+# Fix SimplePublicKey{from_data, to_data, from_amino, to_amino, from_proto, to_proto, address}
+# Fix ValConsPubKey{from_data, to_data, from_amino, to_amino, from_proto, to_proto, address}
+# Fix ModeInfoSingle{from_data, to_data}
+# Fix JSONSerializable.to_data
+# Fix TxInfo.to_data
+# Fix TxLog{from_proto, to_proto}
+# Fix TxBody.from_data
+async def main():
+    async with terra:
+        # Test `SimplePublicKey`
+        simplePublicKey_og = SimplePublicKey.from_data(dict(key=b'A38NTjQrcD4p64693hRsYF4aEdFqhbA8pzRNj3NGO4P3'))
+        data = simplePublicKey_og.to_data()
+        simplePublicKey = SimplePublicKey.from_data(data)
+        print(f'test: SimplePublicKey{{to_data, from_data}} {simplePublicKey_og == simplePublicKey}')
+        amino = simplePublicKey.to_amino()
+        simplePublicKey = SimplePublicKey.from_amino(amino)
+        print(f'test: SimplePublicKey{{to_amino, from_amino}} {simplePublicKey_og == simplePublicKey}')
+        proto = simplePublicKey.to_proto()
+        simplePublicKey = SimplePublicKey.from_proto(proto)
+        print(f'test: SimplePublicKey{{to_proto, from_proto}} {simplePublicKey_og == simplePublicKey}')
+        print(f"SimplePublicKey.address: {simplePublicKey.address()}")
+
+        # Test compatibility with `Key`
+        key = Key(simplePublicKey)
+        print(f'test: SimplePublicKey.address == Key.acc_address {simplePublicKey.address() == key.acc_address}\n')
+
+        # Test `ValConsPubKey`
+        val_pubkey_og = ValConsPubKey.from_data(key.public_key.to_data())
+        data = val_pubkey_og.to_data()
+        val_pubkey = ValConsPubKey.from_data(data)
+        print(f'test: ValConsPubKey{{to_data, from_data}} {val_pubkey_og == val_pubkey}')
+        amino = val_pubkey_og.to_amino()
+        val_pubkey = ValConsPubKey.from_amino(amino)
+        print(f'test: ValConsPubKey{{to_amino, from_amino}} {val_pubkey_og == val_pubkey}')
+        proto = val_pubkey_og.to_proto()
+        val_pubkey = ValConsPubKey.from_proto(proto)
+        print(f'test: ValConsPubKey{{to_proto, from_proto}} {val_pubkey_og == val_pubkey}')
+        print(f'ValConsPubKey.address: {val_pubkey.address()}\n')
+
+        # Test `AsyncTxAPI`{encode, decode, hash}
+        bi = await terra.tendermint.block_info(8787462)
+        # for encoded_tx in bi["block"]["data"]["txs"]:
+        encoded_tx = bi["block"]["data"]["txs"][0]
+        txhash = hash.hash_amino(encoded_tx)
+        # print(txhash)
+        # print(encoded_tx)
+        tx_from_proto = await terra.tx.decode(encoded_tx)
+        # print(decoded_tx)
+        hash_from_proto = await terra.tx.hash(tx_from_proto)
+        # print(hash_from_proto)
+        print(f'hash_from_proto==txhash {hash_from_proto == txhash}')
+        if hash_from_proto != txhash:
+            tx_info = await terra.tx.tx_info(txhash)
+            tx_from_data = tx_info.tx
+            hash_from_data = await terra.tx.hash(tx_from_data)
+            print(f'hash_from_data==txhash {hash_from_data == txhash}')
+            print(f'hash_from_data==hash_from_proto {hash_from_data == hash_from_proto}')
+            print(f'tx_from_proto==tx_from_data {tx_from_proto == tx_from_data}')
+            if tx_from_proto != tx_from_data:
+                print(tx_from_data)
+                print(tx_from_proto)
+
+        encoded_tx = await terra.tx.encode(tx_from_proto)
+        print(f'encoded_tx==encoded_tx {encoded_tx == encoded_tx}')
+        # print(new_encoded_tx)
+        decoded_tx = await terra.tx.decode(encoded_tx)
+        print(f'decoded_tx==tx_from_proto {decoded_tx == tx_from_proto}\n')
+
+        # Test `Tx`, `TxLog` and `TxInfo`
+        txhash_og = 'FB1A18E18078173DC90A80EB2843CD94DC3ACC1E61BAAD1CCDB92AA666FA14E3'
+        tx_og = await terra.tx.tx_info(txhash_og)
+        data = tx_og.to_data()
+        tx = TxInfo.from_data(data)
+        print(f'test: Tx{{to_data, from_data}} {tx.tx == tx_og.tx}')
+        print(f'test: TxBody{{to_data, from_data}} {tx.tx.body == tx_og.tx.body}')
+        print(f'test: TxInfo{{to_data, from_data}} {tx == tx_og}')
+        if tx != tx_og:
+            print(tx)
+            print(tx_og)
+        proto = tx.to_proto()
+        tx = TxInfo.from_proto(proto)
+        print(f'test: Tx{{to_proto, from_proto}} {tx.tx == tx_og.tx}')
+        print(f'test: TxLog{{to_proto, from_proto}} {tx.logs == tx_og.logs}')
+        print(f'test: TxInfo{{to_proto, from_proto}} {tx == tx_og}')
+        if tx != tx_og:
+            print(tx)
+            print(tx_og)
+
+
+if __name__ == '__main__':
+    asyncio.get_event_loop().run_until_complete(main())

--- a/terra_sdk/client/lcd/api/tx.py
+++ b/terra_sdk/client/lcd/api/tx.py
@@ -255,7 +255,7 @@ class AsyncTxAPI(BaseAsyncAPI):
         Returns:
             str: transaction hash
         """
-        amino = self.encode(tx)
+        amino = await self.encode(tx)
         return hash_amino(amino)
 
     async def _broadcast(

--- a/terra_sdk/core/mode_info.py
+++ b/terra_sdk/core/mode_info.py
@@ -62,11 +62,11 @@ class ModeInfoSingle(JSONSerializable):
     mode: SignMode = attr.ib()
 
     def to_data(self) -> dict:
-        return {"mode": self.mode}
+        return {"mode": self.mode.name}
 
     @classmethod
     def from_data(cls, data: dict) -> ModeInfoSingle:
-        return cls(data["mode"])
+        return cls(SignMode[data["mode"]])
 
     def to_proto(self) -> ModeInfoSingle_pb:
         return ModeInfoSingle_pb(mode=self.mode)

--- a/terra_sdk/core/public_key.py
+++ b/terra_sdk/core/public_key.py
@@ -150,10 +150,10 @@ class SimplePublicKey(PublicKey):
     key: bytes = attr.ib()
 
     def to_amino(self) -> dict:
-        return {"type": self.type_amino, "value": self.key}
+        return {"type": self.type_amino, "value": base64.b64encode(self.key)}
 
     def to_data(self) -> dict:
-        return {"@type": self.type_url, "key": self.key}
+        return {"@type": self.type_url, "key": base64.b64encode(self.key)}
 
     @classmethod
     def from_data(cls, data: dict) -> SimplePublicKey:
@@ -186,7 +186,7 @@ class SimplePublicKey(PublicKey):
         return address_from_public_key(self)
 
     def address(self) -> str:
-        return get_bech("terra", self.raw_address())
+        return get_bech("terra", self.raw_address().hex())
 
 
 @attr.s
@@ -199,13 +199,13 @@ class ValConsPubKey(PublicKey):
     type_url = "/cosmos.crypto.ed25519.PubKey"
     """an ed25519 tendermint public key type."""
 
-    key: str = attr.ib()
+    key: bytes = attr.ib()
 
     def to_amino(self) -> dict:
-        return {"type": self.type_amino, "value": self.key}
+        return {"type": self.type_amino, "value": base64.b64encode(self.key)}
 
     def to_data(self) -> dict:
-        return {"@type": self.type_url, "key": self.key}
+        return {"@type": self.type_url, "key": base64.b64encode(self.key)}
 
     @classmethod
     def from_data(cls, data: dict) -> ValConsPubKey:
@@ -213,11 +213,11 @@ class ValConsPubKey(PublicKey):
 
     @classmethod
     def from_amino(cls, amino: dict) -> ValConsPubKey:
-        return cls(key=base64.b64decode(amino["value"]["key"]))
+        return cls(key=base64.b64decode(amino["value"]))
 
     @classmethod
     def from_proto(cls, proto: ValConsPubKey_pb) -> ValConsPubKey:
-        return cls(key=proto.key)
+        return cls(key=base64.b64decode(proto.key))
 
     def get_type(self) -> str:
         return self.type_url
@@ -231,11 +231,11 @@ class ValConsPubKey(PublicKey):
     def encode_amino_pubkey(self) -> bytes:
         return bytes.fromhex(BECH32_AMINO_PUBKEY_DATA_PREFIX_ED25519) + bytes(self.key)
 
-    def raw_address(self) -> str:
-        return address_from_public_key(self.key)
+    def raw_address(self) -> bytes:
+        return address_from_public_key(self)
 
     def address(self) -> str:
-        return get_bech("terravalcons", self.raw_address())
+        return get_bech("terravalcons", self.raw_address().hex())
 
 
 @attr.s

--- a/terra_sdk/util/json.py
+++ b/terra_sdk/util/json.py
@@ -8,7 +8,7 @@ from terra_sdk.util.converter import to_isoformat
 
 
 def to_data(x: Any) -> Any:
-    if "to_data" in dir(x):
+    if hasattr(x, "to_data"):
         return x.to_data()
     if isinstance(x, int):
         return str(x)
@@ -50,7 +50,7 @@ def dict_to_data(d: dict) -> dict:
 class JSONSerializable(ABC):
     def to_data(self) -> Any:
         """Converts the object to its JSON-serializable Python data representation."""
-        pass  # return dict_to_data(copy.deepcopy(self.__dict__))
+        return dict_to_data(copy.deepcopy(self.__dict__))
 
     def to_json(self) -> str:
         """Marshals the object into a stringified JSON serialization. Keys are first sorted


### PR DESCRIPTION
…le | TxInfo | TxLog | TxBody conversions

fixes: https://github.com/terra-money/terra.py/issues/100, https://github.com/terra-money/terra.py/issues/111

Conversion methods like {from_data, to_data, from_amino, to_amino, from_proto, to_proto} in SimplePublicKey | ValConsPubKey | ModeInfoSingle | JSONSerializable | TxInfo | TxLog | TxBody are fixed. Tests are provided in `integration_tests.public_key&txinfo`.

Note: `Tx` objects can be retrieved by `from_proto` using encoded tx protos returned by `terra.tendermint.block_info()`, or by `from_data` using data returned by `terra.tx.tx_info(txhash)`. However, due to data conversions in the reconstruction process, `Tx` instance rebuilt by `from_proto` or `from_data` may be different from `Tx` instance converted to bytes when broadcasting the transaction. Therefore, the hash calculated from the reconstructed `Tx` may be different than the hash of the original `Tx`.

The reconstructed `Tx` has all the available information. It's just not the same instance used to broadcast the transaction. `TxAPI.encode` and `TxAPI.decode` are reversible. But `TxAPI.encode` may give a different string on a reconstructed `Tx`.