### PR TITLE
add `from_amino/to_data` for most `Msg` types

### DIFF
--- a/integration_tests/from_proto.py
+++ b/integration_tests/from_proto.py
@@ -1,0 +1,47 @@
+from terra_sdk.client.lcd import AsyncLCDClient
+from terra_sdk.core import Coins
+from terra_sdk.core.authz import MsgExecAuthorized
+from terra_sdk.core.bank import MsgMultiSend
+from terra_sdk.core.crisis import MsgVerifyInvariant
+import requests, asyncio
+
+light_clinet_address = 'https://lcd.terra.dev'
+chain_id = 'columbus-5'
+gas_prices = requests.get('https://fcd.terra.dev/v1/txs/gas_prices').json()
+terra = AsyncLCDClient(chain_id=chain_id,
+                       url=light_clinet_address,
+                       gas_prices=Coins(uusd=gas_prices['uusd']),
+                       gas_adjustment=1.2)
+
+
+async def main():
+    async with terra:
+        height = 0
+        types = {}
+        while True:
+            bi = await terra.tendermint.block_info()
+            block = bi['block']
+            if height != block['header']['height']:
+                height = block['header']['height']
+                for encoded_tx in block['data']['txs']:
+                    try:
+                        tx = await terra.tx.decode(encoded_tx)
+                        for msg in tx.body.messages:
+                            if isinstance(msg, MsgExecAuthorized):
+                                print('MsgExecAuthorized.from_proto fixed')
+                            elif isinstance(msg, MsgMultiSend):
+                                print('MsgMultiSend.unpack_any fixed')
+                            elif isinstance(msg, MsgVerifyInvariant):
+                                print('MsgVerifyInvariant.unpack_any fixed')
+                            else:
+                                t = type(msg)
+                                if t.__name__ not in types:
+                                    types[t.__name__] = t
+                                    print(f'{t.__name__}.from_proto/unpack_any checked')
+                    except Exception as exc:
+                        print(exc)
+            await asyncio.sleep(7)
+
+
+if __name__ == '__main__':
+    asyncio.get_event_loop().run_until_complete(main())

--- a/integration_tests/public_key&txinfo.py
+++ b/integration_tests/public_key&txinfo.py
@@ -77,10 +77,10 @@ async def main():
                 print(tx_from_data)
                 print(tx_from_proto)
 
-        encoded_tx = await terra.tx.encode(tx_from_proto)
-        print(f'encoded_tx==encoded_tx {encoded_tx == encoded_tx}')
+        new_encoded_tx = await terra.tx.encode(tx_from_proto)
+        print(f'new_encoded_tx==encoded_tx {new_encoded_tx == encoded_tx}')
         # print(new_encoded_tx)
-        decoded_tx = await terra.tx.decode(encoded_tx)
+        decoded_tx = await terra.tx.decode(new_encoded_tx)
         print(f'decoded_tx==tx_from_proto {decoded_tx == tx_from_proto}\n')
 
         # Test `Tx`, `TxLog` and `TxInfo`

--- a/terra_sdk/core/authz/msgs.py
+++ b/terra_sdk/core/authz/msgs.py
@@ -66,7 +66,7 @@ class MsgExecAuthorized(Msg):
     @classmethod
     def from_proto(cls, proto: MsgExec_pb) -> MsgExecAuthorized:
         return cls(
-            grantee=proto.grantee, msgs=[Msg.from_proto(md) for md in proto.msgs]
+            grantee=proto.grantee, msgs=[Msg.unpack_any(md) for md in proto.msgs]
         )
 
     @classmethod
@@ -172,6 +172,15 @@ class MsgRevokeAuthorization(Msg):
     granter: AccAddress = attr.ib()
     grantee: AccAddress = attr.ib()
     msg_type_url: str = attr.ib()
+
+    @classmethod
+    def from_amino(cls, amino: dict) -> MsgRevokeAuthorization:
+        value = amino["value"]
+        return cls(
+            granter=value["granter"],
+            grantee=value["grantee"],
+            msg_type_url=value["msg_type_url"]
+        )
 
     def to_amino(self) -> dict:
         return {

--- a/terra_sdk/core/bank/msgs.py
+++ b/terra_sdk/core/bank/msgs.py
@@ -43,6 +43,15 @@ class MsgSend(Msg):
     to_address: AccAddress = attr.ib()
     amount: Coins = attr.ib(converter=Coins)
 
+    @classmethod
+    def from_amino(cls, amino: dict) -> MsgSend:
+        assert cls.type_amino == amino["type"]
+        return cls(
+            from_address=amino["value"]["from_address"],
+            to_address=amino["value"]["to_address"],
+            amount=Coins.from_amino(amino["value"]["amount"]),
+        )
+
     def to_amino(self) -> dict:
         return {
             "type": self.type_amino,
@@ -101,6 +110,13 @@ class MultiSendInput(JSONSerializable):
     coins: Coins = attr.ib(converter=Coins)
     """Coins to be sent."""
 
+    @classmethod
+    def from_amino(cls, amino: dict) -> MultiSendInput:
+        return cls(
+            address=amino["value"]["address"],
+            coins=Coins.from_amino(amino["value"]["coins"]),
+        )
+
     def to_amino(self) -> dict:
         return {"address": self.address, "coins": self.coins.to_amino()}
 
@@ -137,6 +153,13 @@ class MultiSendOutput(JSONSerializable):
 
     coins: Coins = attr.ib(converter=Coins)
     """Coins to be received."""
+
+    @classmethod
+    def from_amino(cls, amino: dict) -> MultiSendOutput:
+        return cls(
+            address=amino["value"]["address"],
+            coins=Coins.from_amino(amino["value"]["coins"]),
+        )
 
     def to_amino(self) -> dict:
         return {"address": self.address, "coins": self.coins.to_amino()}
@@ -196,6 +219,14 @@ class MsgMultiSend(Msg):
     inputs: List[MultiSendInput] = attr.ib(converter=convert_input_list)
     outputs: List[MultiSendOutput] = attr.ib(converter=convert_output_list)
 
+    @classmethod
+    def from_amino(cls, amino: dict) -> MsgMultiSend:
+        assert cls.type_amino == amino["type"]
+        return cls(
+            inputs=[MultiSendInput.from_amino(x) for x in amino["value"]["inputs"]],
+            outputs=[MultiSendOutput.from_amino(x) for x in amino["value"]["outputs"]],
+        )
+
     def to_amino(self) -> dict:
         return {
             "type": self.type_amino,
@@ -234,4 +265,4 @@ class MsgMultiSend(Msg):
 
     @classmethod
     def unpack_any(cls, any_pb: Any_pb) -> MsgMultiSend:
-        return cls.from_proto(MsgMultiSend_pb().parse(any_pb))
+        return cls.from_proto(MsgMultiSend_pb().parse(any_pb.value))

--- a/terra_sdk/core/crisis/msgs.py
+++ b/terra_sdk/core/crisis/msgs.py
@@ -68,4 +68,4 @@ class MsgVerifyInvariant(Msg):
 
     @classmethod
     def unpack_any(cls, any_pb: Any_pb) -> MsgVerifyInvariant:
-        return MsgVerifyInvariant.from_proto(any_pb)
+        return cls.from_proto(MsgVerifyInvariant_pb().parse(any_pb.value))

--- a/terra_sdk/core/distribution/msgs.py
+++ b/terra_sdk/core/distribution/msgs.py
@@ -48,6 +48,14 @@ class MsgSetWithdrawAddress(Msg):
     delegator_address: AccAddress = attr.ib()
     withdraw_address: AccAddress = attr.ib()
 
+    @classmethod
+    def from_amino(cls, amino: dict) -> MsgSetWithdrawAddress:
+        assert cls.type_amino == amino["type"]
+        return cls(
+            delegator_address=amino["value"]["delegator_address"],
+            withdraw_address=amino["value"]["withdraw_address"],
+        )
+
     def to_amino(self) -> dict:
         return {
             "type": self.type_amino,
@@ -78,10 +86,10 @@ class MsgSetWithdrawAddress(Msg):
         )
 
     @classmethod
-    def from_proto(cls, data: MsgSetWithdrawAddress_pb) -> MsgSetWithdrawAddress:
+    def from_proto(cls, proto: MsgSetWithdrawAddress_pb) -> MsgSetWithdrawAddress:
         return cls(
-            delegator_address=data["delegator_address"],
-            withdraw_address=data["withdraw_address"],
+            delegator_address=proto.delegator_address,
+            withdraw_address=proto.withdraw_address,
         )
 
 
@@ -105,6 +113,14 @@ class MsgWithdrawDelegatorReward(Msg):
 
     delegator_address: AccAddress = attr.ib()
     validator_address: ValAddress = attr.ib()
+
+    @classmethod
+    def from_amino(cls, amino: dict) -> MsgWithdrawDelegatorReward:
+        assert cls.type_amino == amino["type"]
+        return cls(
+            delegator_address=amino["value"]["delegator_address"],
+            validator_address=amino["value"]["validator_address"],
+        )
 
     def to_amino(self) -> dict:
         return {
@@ -164,6 +180,11 @@ class MsgWithdrawValidatorCommission(Msg):
 
     validator_address: ValAddress = attr.ib()
 
+    @classmethod
+    def from_amino(cls, amino: dict) -> MsgWithdrawValidatorCommission:
+        assert cls.type_amino == amino["type"]
+        return cls(validator_address=amino["value"]["validator_address"])
+
     def to_amino(self) -> dict:
         return {
             "type": self.type_amino,
@@ -184,9 +205,9 @@ class MsgWithdrawValidatorCommission(Msg):
 
     @classmethod
     def from_proto(
-        cls, data: MsgWithdrawValidatorCommission_pb
+        cls, proto: MsgWithdrawValidatorCommission_pb
     ) -> MsgWithdrawValidatorCommission:
-        return cls(validator_address=data["validator_address"])
+        return cls(validator_address=proto.validator_address)
 
 
 @attr.s
@@ -207,6 +228,14 @@ class MsgFundCommunityPool(Msg):
 
     depositor: AccAddress = attr.ib()
     amount: Coins = attr.ib(converter=Coins)
+
+    @classmethod
+    def from_amino(cls, amino: dict) -> MsgFundCommunityPool:
+        assert cls.type_amino == amino["type"]
+        return cls(
+            depositor=amino["value"]["depositor"],
+            amount=Coins.from_amino(amino["value"]["amount"]),
+        )
 
     def to_amino(self) -> dict:
         return {
@@ -231,5 +260,5 @@ class MsgFundCommunityPool(Msg):
         )
 
     @classmethod
-    def from_proto(cls, data: MsgFundCommunityPool_pb) -> MsgFundCommunityPool:
-        return cls(depositor=data["depositor"], amount=Coins.from_proto(data["amount"]))
+    def from_proto(cls, proto: MsgFundCommunityPool_pb) -> MsgFundCommunityPool:
+        return cls(depositor=proto.depositor, amount=Coins.from_proto(proto.amount))

--- a/terra_sdk/core/feegrant/msgs.py
+++ b/terra_sdk/core/feegrant/msgs.py
@@ -36,6 +36,15 @@ class MsgGrantAllowance(Msg):
     prototype = MsgGrantAllowance_pb
     """"""
 
+    @classmethod
+    def from_amino(cls, amino: dict) -> MsgGrantAllowance:
+        assert cls.type_amino == amino["type"]
+        return cls(
+            granter=amino["value"]["granter"],
+            grantee=amino["value"]["grantee"],
+            allowance=Allowance.from_amino(amino["value"]["allowance"]),
+        )
+
     def to_amino(self) -> dict:
         return {
             "type": self.type_amino,
@@ -44,6 +53,13 @@ class MsgGrantAllowance(Msg):
                 "grantee": self.grantee,
                 "allowance": self.allowance.to_amino(),
             },
+        }
+
+    def to_data(self) -> dict:
+        return {
+            "granter": self.granter,
+            "grantee": self.grantee,
+            "allowance": self.allowance.to_data(),
         }
 
     @classmethod
@@ -84,10 +100,24 @@ class MsgRevokeAllowance(Msg):
     prototype = MsgRevokeAllowance_pb
     """"""
 
+    @classmethod
+    def from_amino(cls, amino: dict) -> MsgRevokeAllowance:
+        assert cls.type_amino == amino["type"]
+        return cls(
+            granter=amino["value"]["granter"],
+            grantee=amino["value"]["grantee"],
+        )
+
     def to_amino(self) -> dict:
         return {
             "type": self.type_amino,
             "value": {"granter": self.granter, "grantee": self.grantee},
+        }
+
+    def to_data(self) -> dict:
+        return {
+            "granter": self.granter,
+            "grantee": self.grantee,
         }
 
     @classmethod

--- a/terra_sdk/core/gov/msgs.py
+++ b/terra_sdk/core/gov/msgs.py
@@ -38,6 +38,18 @@ class MsgSubmitProposal(Msg):
     initial_deposit: Coins = attr.ib(converter=Coins)
     proposer: AccAddress = attr.ib()
 
+    @classmethod
+    def from_amino(cls, amino: dict) -> MsgSubmitProposal:
+        assert cls.type_amino == amino["type"]
+        from terra_sdk.util.parse_content import parse_content
+
+        content = parse_content(amino["value"]["content"])
+        return cls(
+            content=content,
+            initial_deposit=Coins.from_amino(amino["value"]["initial_deposit"]),
+            proposer=amino["value"]["proposer"],
+        )
+
     def to_amino(self) -> dict:
         return {
             "type": self.type_amino,
@@ -107,6 +119,15 @@ class MsgDeposit(Msg):
     proposal_id: int = attr.ib(converter=int)
     depositor: AccAddress = attr.ib()
     amount: Coins = attr.ib(converter=Coins)
+
+    @classmethod
+    def from_amino(cls, amino: dict) -> MsgDeposit:
+        assert cls.type_amino == amino["type"]
+        return cls(
+            proposal_id=amino["value"]["proposal_id"],
+            depositor=amino["value"]["depositor"],
+            amount=Coins.from_amino(amino["value"]["amount"]),
+        )
 
     def to_amino(self) -> dict:
         return {
@@ -200,6 +221,15 @@ class MsgVote(Msg):
                 f"incorrect value for option: {value}, must be one of: {possible_options}"
             )
     """
+
+    @classmethod
+    def from_amino(cls, amino: dict) -> MsgVote:
+        assert cls.type_amino == amino["type"]
+        return cls(
+            proposal_id=amino["value"]["proposal_id"],
+            voter=amino["value"]["voter"],
+            option=amino["value"]["option"],
+        )
 
     def to_amino(self) -> dict:
         return {

--- a/terra_sdk/core/market/msgs.py
+++ b/terra_sdk/core/market/msgs.py
@@ -35,6 +35,15 @@ class MsgSwap(Msg):
     offer_coin: Coin = attr.ib(converter=Coin.parse)  # type: ignore
     ask_denom: str = attr.ib()
 
+    @classmethod
+    def from_amino(cls, amino: dict) -> MsgSwap:
+        assert cls.type_amino == amino["type"]
+        return cls(
+            trader=amino["value"]["trader"],
+            offer_coin=Coin.from_amino(amino["value"]["offer_coin"]),
+            ask_denom=amino["value"]["ask_denom"],
+        )
+
     def to_amino(self) -> dict:
         return {
             "type": self.type_amino,
@@ -43,6 +52,13 @@ class MsgSwap(Msg):
                 "offer_coin": self.offer_coin.to_amino(),
                 "ask_denom": self.ask_denom,
             },
+        }
+
+    def to_data(self) -> dict:
+        return {
+            "trader": self.trader,
+            "offer_coin": self.offer_coin.to_data(),
+            "ask_denom": self.ask_denom,
         }
 
     @classmethod
@@ -94,6 +110,16 @@ class MsgSwapSend(Msg):
     offer_coin: Coin = attr.ib(converter=Coin.parse)  # type: ignore
     ask_denom: str = attr.ib()
 
+    @classmethod
+    def from_amino(cls, amino: dict) -> MsgSwapSend:
+        assert cls.type_amino == amino["type"]
+        return cls(
+            from_address=amino["value"]["from_address"],
+            to_address=amino["value"]["to_address"],
+            offer_coin=Coin.from_amino(amino["value"]["offer_coin"]),
+            ask_denom=amino["value"]["ask_denom"],
+        )
+
     def to_amino(self) -> dict:
         return {
             "type": self.type_amino,
@@ -103,6 +129,14 @@ class MsgSwapSend(Msg):
                 "offer_coin": self.offer_coin.to_amino(),
                 "ask_denom": self.ask_denom,
             },
+        }
+
+    def to_data(self) -> dict:
+        return {
+            "from_address": self.from_address,
+            "to_address": self.to_address,
+            "offer_coin": self.offer_coin.to_data(),
+            "ask_denom": self.ask_denom,
         }
 
     @classmethod

--- a/terra_sdk/core/oracle/msgs.py
+++ b/terra_sdk/core/oracle/msgs.py
@@ -81,10 +81,24 @@ class MsgDelegateFeedConsent(Msg):
     operator: ValAddress = attr.ib()
     delegate: AccAddress = attr.ib()
 
+    @classmethod
+    def from_amino(cls, amino: dict) -> MsgDelegateFeedConsent:
+        assert cls.type_amino == amino["type"]
+        return cls(
+            operator=amino["value"]["operator"],
+            delegate=amino["value"]["delegate"],
+        )
+
     def to_amino(self) -> dict:
         return {
             "type": self.type_amino,
             "value": {"operator": self.operator, "delegate": self.delegate},
+        }
+
+    def to_data(self) -> dict:
+        return {
+            "operator": self.operator,
+            "delegate": self.delegate,
         }
 
     @classmethod
@@ -120,6 +134,15 @@ class MsgAggregateExchangeRatePrevote(Msg):
     feeder: AccAddress = attr.ib()
     validator: ValAddress = attr.ib()
 
+    @classmethod
+    def from_amino(cls, amino: dict) -> MsgAggregateExchangeRatePrevote:
+        assert cls.type_amino == amino["type"]
+        return cls(
+            hash=amino["value"]["hash"],
+            feeder=amino["value"]["feeder"],
+            validator=amino["value"]["validator"],
+        )
+
     def to_amino(self) -> dict:
         return {
             "type": self.type_amino,
@@ -128,6 +151,13 @@ class MsgAggregateExchangeRatePrevote(Msg):
                 "feeder": self.feeder,
                 "validator": self.validator,
             },
+        }
+
+    def to_data(self) -> dict:
+        return {
+            "hash": self.hash,
+            "feeder": self.feeder,
+            "validator": self.validator,
         }
 
     @classmethod
@@ -176,6 +206,21 @@ class MsgAggregateExchangeRateVote(Msg):
     salt: str = attr.ib()
     feeder: AccAddress = attr.ib()
     validator: ValAddress = attr.ib()
+
+    @classmethod
+    def from_amino(cls, amino: dict) -> MsgAggregateExchangeRateVote:
+        assert cls.type_amino == amino["type"]
+        rates = amino["value"].get("exchange_rates")
+        if type(rates) is str:
+            rates = Coins.from_str(rates)
+        else:
+            rates = Coins.from_amino(rates)
+        return cls(
+            exchange_rates=rates,
+            salt=amino["value"].get("salt"),
+            feeder=amino["value"].get("feeder"),
+            validator=amino["value"].get("validator"),
+        )
 
     def to_amino(self) -> dict:
         return {

--- a/terra_sdk/core/slashing/msgs.py
+++ b/terra_sdk/core/slashing/msgs.py
@@ -29,8 +29,16 @@ class MsgUnjail(Msg):
 
     address: ValAddress = attr.ib()
 
+    @classmethod
+    def from_amino(cls, amino: dict) -> MsgUnjail:
+        assert cls.type_amino == amino["type"]
+        return cls(address=amino["value"]["address"])
+
     def to_amino(self) -> dict:
         return {"type": self.type_amino, "value": {"address": self.address}}
+
+    def to_data(self) -> dict:
+        return {"address": self.address}
 
     @classmethod
     def from_data(cls, data: dict) -> MsgUnjail:

--- a/terra_sdk/core/staking/msgs.py
+++ b/terra_sdk/core/staking/msgs.py
@@ -54,6 +54,16 @@ class MsgBeginRedelegate(Msg):
     validator_dst_address: ValAddress = attr.ib()
     amount: Coin = attr.ib(converter=Coin.parse)
 
+    @classmethod
+    def from_amino(cls, amino: dict) -> MsgBeginRedelegate:
+        assert cls.type_amino == amino["type"]
+        return cls(
+            delegator_address=amino["value"]["delegator_address"],
+            validator_src_address=amino["value"]["validator_src_address"],
+            validator_dst_address=amino["value"]["validator_dst_address"],
+            amount=Coin.from_amino(amino["value"]["amount"]),
+        )
+
     def to_amino(self) -> dict:
         return {
             "type": self.type_amino,
@@ -63,6 +73,14 @@ class MsgBeginRedelegate(Msg):
                 "validator_dst_address": self.validator_dst_address,
                 "amount": self.amount.to_amino(),
             },
+        }
+
+    def to_data(self) -> dict:
+        return {
+            "delegator_address": self.delegator_address,
+            "validator_src_address": self.validator_src_address,
+            "validator_dst_address": self.validator_dst_address,
+            "amount": self.amount.to_data(),
         }
 
     @classmethod
@@ -115,6 +133,15 @@ class MsgDelegate(Msg):
     validator_address: ValAddress = attr.ib()
     amount: Coin = attr.ib(converter=Coin.parse)
 
+    @classmethod
+    def from_amino(cls, amino: dict) -> MsgDelegate:
+        assert cls.type_amino == amino["type"]
+        return cls(
+            delegator_address=amino["value"]["delegator_address"],
+            validator_address=amino["value"]["validator_address"],
+            amount=Coin.from_amino(amino["value"]["amount"]),
+        )
+
     def to_amino(self) -> dict:
         return {
             "type": self.type_amino,
@@ -123,6 +150,13 @@ class MsgDelegate(Msg):
                 "validator_address": self.validator_address,
                 "amount": self.amount.to_amino(),
             },
+        }
+
+    def to_data(self) -> dict:
+        return {
+            "delegator_address": self.delegator_address,
+            "validator_address": self.validator_address,
+            "amount": self.amount.to_data(),
         }
 
     @classmethod
@@ -172,6 +206,15 @@ class MsgUndelegate(Msg):
     validator_address: ValAddress = attr.ib()
     amount: Coin = attr.ib(converter=Coin.parse)
 
+    @classmethod
+    def from_amino(cls, amino: dict) -> MsgUndelegate:
+        assert cls.type_amino == amino["type"]
+        return cls(
+            delegator_address=amino["value"]["delegator_address"],
+            validator_address=amino["value"]["validator_address"],
+            amount=Coin.from_amino(amino["value"]["amount"]),
+        )
+
     def to_amino(self) -> dict:
         return {
             "type": self.type_amino,
@@ -180,6 +223,13 @@ class MsgUndelegate(Msg):
                 "validator_address": self.validator_address,
                 "amount": self.amount.to_amino(),
             },
+        }
+
+    def to_data(self) -> dict:
+        return {
+            "delegator_address": self.delegator_address,
+            "validator_address": self.validator_address,
+            "amount": self.amount.to_data(),
         }
 
     @classmethod
@@ -231,12 +281,20 @@ class MsgEditValidator(Msg):
     commission_rate: Optional[Dec] = attr.ib(default=None)
     min_self_delegation: Optional[int] = attr.ib(default=None)
 
+    def to_data(self) -> dict:
+        return {
+            "description": self.description.to_data(),
+            "validator_address": self.validator_address,
+            "commission_rate": self.commission_rate,
+            "min_self_delegation": self.min_self_delegation,
+        }
+
     @classmethod
     def from_data(cls, data: dict) -> MsgEditValidator:
         msd = int(data["min_self_delegation"]) if data["min_self_delegation"] else None
         cr = Dec(data["commission_rate"]) if data["commission_rate"] else None
         return cls(
-            description=data["description"],
+            description=Description.from_data(data["description"]),
             validator_address=data["validator_address"],
             commission_rate=cr,
             min_self_delegation=msd,
@@ -295,15 +353,26 @@ class MsgCreateValidator(Msg):
     pubkey: ValConsPubKey = attr.ib()
     value: Coin = attr.ib(converter=Coin.parse)  # type: ignore
 
+    def to_data(self) -> dict:
+        return {
+            "description": self.description.to_data(),
+            "commission": self.commission.to_data(),
+            "min_self_delegation": self.min_self_delegation,
+            "delegator_address": self.delegator_address,
+            "validator_address": self.validator_address,
+            "pubkey": self.pubkey.to_data(),
+            "value": self.value.to_data(),
+        }
+
     @classmethod
     def from_data(cls, data: dict) -> MsgCreateValidator:
         return cls(
             description=Description.from_data(data["description"]),
             commission=CommissionRates.from_data(data["commission"]),
-            min_self_delegation=int(data["min_self_delegation"]),
+            min_self_delegation=data["min_self_delegation"],
             delegator_address=data["delegator_address"],
             validator_address=data["validator_address"],
-            pubkey=data["pubkey"],
+            pubkey=ValConsPubKey.from_data(data["pubkey"]),
             value=Coin.from_data(data["value"]),
         )
 

--- a/terra_sdk/core/wasm/msgs.py
+++ b/terra_sdk/core/wasm/msgs.py
@@ -62,6 +62,14 @@ class MsgStoreCode(Msg):
     sender: AccAddress = attr.ib()
     wasm_byte_code: str = attr.ib()
 
+    @classmethod
+    def from_amino(cls, amino: dict) -> MsgStoreCode:
+        assert cls.type_amino == amino["type"]
+        return cls(
+            sender=amino["value"]["sender"],
+            wasm_byte_code=amino["value"]["wasm_byte_code"],
+        )
+
     def to_amino(self) -> dict:
         return {
             "type": self.type_amino,
@@ -71,6 +79,12 @@ class MsgStoreCode(Msg):
     @classmethod
     def from_data(cls, data: dict) -> MsgStoreCode:
         return cls(sender=data["sender"], wasm_byte_code=data["wasm_byte_code"])
+
+    def to_data(self) -> dict:
+        return {
+            "sender": self.sender,
+            "wasm_byte_code": self.wasm_byte_code,
+        }
 
     def to_proto(self) -> MsgStoreCode_pb:
         return MsgStoreCode_pb(
@@ -104,6 +118,15 @@ class MsgMigrateCode(Msg):
     code_id: int = attr.ib(converter=int)
     wasm_byte_code: str = attr.ib(converter=str)
 
+    @classmethod
+    def from_amino(cls, amino: dict) -> MsgMigrateCode:
+        assert cls.type_amino == amino["type"]
+        return cls(
+            sender=amino["value"]["sender"],
+            code_id=amino["value"]["code_id"],
+            wasm_byte_code=amino["value"]["wasm_byte_code"],
+        )
+
     def to_amino(self) -> dict:
         return {
             "type": self.type_amino,
@@ -121,6 +144,13 @@ class MsgMigrateCode(Msg):
             code_id=data["code_id"],
             wasm_byte_code=data["wasm_byte_code"],
         )
+
+    def to_data(self) -> dict:
+        return {
+            "sender": self.sender,
+            "code_id": str(self.code_id),
+            "wasm_byte_code": self.wasm_byte_code,
+        }
 
     def to_proto(self) -> MsgMigrateCode_pb:
         return MsgMigrateCode_pb(
@@ -161,6 +191,17 @@ class MsgInstantiateContract(Msg):
     init_msg: Union[dict, str] = attr.ib()
     init_coins: Coins = attr.ib(converter=Coins, factory=Coins)
 
+    @classmethod
+    def from_amino(cls, amino: dict) -> MsgInstantiateContract:
+        assert cls.type_amino == amino["type"]
+        return cls(
+            sender=amino["value"]["sender"],
+            admin=amino["value"]["admin"],
+            code_id=amino["value"]["code_id"],
+            init_msg=amino["value"]["init_msg"],
+            init_coins=Coins.from_amino(amino["value"]["init_coins"]),
+        )
+
     def to_amino(self) -> dict:
         return {
             "type": self.type_amino,
@@ -171,6 +212,15 @@ class MsgInstantiateContract(Msg):
                 "init_msg": remove_none(self.init_msg),
                 "init_coins": self.init_coins.to_amino(),
             },
+        }
+
+    def to_data(self) -> dict:
+        return {
+            "sender": self.sender,
+            "admin": self.admin,
+            "code_id": str(self.code_id),
+            "init_msg": remove_none(self.init_msg),
+            "init_coins": self.init_coins.to_data(),
         }
 
     @classmethod
@@ -227,6 +277,16 @@ class MsgExecuteContract(Msg):
     execute_msg: Union[dict, str] = attr.ib()
     coins: Coins = attr.ib(converter=Coins, factory=Coins)
 
+    @classmethod
+    def from_amino(cls, amino: dict) -> MsgExecuteContract:
+        assert cls.type_amino == amino["type"]
+        return cls(
+            sender=amino["value"]["sender"],
+            contract=amino["value"]["contract"],
+            execute_msg=parse_msg(amino["value"]["execute_msg"]),
+            coins=Coins.from_amino(amino["value"]["coins"]),
+        )
+
     def to_amino(self) -> dict:
         return {
             "type": self.type_amino,
@@ -236,6 +296,14 @@ class MsgExecuteContract(Msg):
                 "execute_msg": remove_none(self.execute_msg),
                 "coins": self.coins.to_amino(),
             },
+        }
+
+    def to_data(self) -> dict:
+        return {
+            "sender": self.sender,
+            "contract": self.contract,
+            "execute_msg": remove_none(self.execute_msg),
+            "coins": self.coins.to_data(),
         }
 
     @classmethod
@@ -288,6 +356,16 @@ class MsgMigrateContract(Msg):
     new_code_id: int = attr.ib(converter=int)
     migrate_msg: Union[dict, str] = attr.ib()
 
+    @classmethod
+    def from_amino(cls, amino: dict) -> MsgMigrateContract:
+        assert cls.type_amino == amino["type"]
+        return cls(
+            admin=amino["value"]["admin"],
+            contract=amino["value"]["contract"],
+            new_code_id=amino["value"]["new_code_id"],
+            migrate_msg=parse_msg(amino["value"]["migrate_msg"]),
+        )
+
     def to_amino(self) -> dict:
         return {
             "type": self.type_amino,
@@ -297,6 +375,14 @@ class MsgMigrateContract(Msg):
                 "new_code_id": str(self.new_code_id),
                 "migrate_msg": remove_none(self.migrate_msg),
             },
+        }
+
+    def to_data(self) -> dict:
+        return {
+            "admin": self.admin,
+            "contract": self.contract,
+            "new_code_id": str(self.new_code_id),
+            "migrate_msg": remove_none(self.migrate_msg),
         }
 
     @classmethod
@@ -347,6 +433,15 @@ class MsgUpdateContractAdmin(Msg):
     new_admin: AccAddress = attr.ib()
     contract: AccAddress = attr.ib()
 
+    @classmethod
+    def from_amino(cls, amino: dict) -> MsgUpdateContractAdmin:
+        assert cls.type_amino == amino["type"]
+        return cls(
+            admin=amino["value"]["admin"],
+            new_admin=amino["value"]["new_admin"],
+            contract=amino["value"]["contract"],
+        )
+
     def to_amino(self) -> dict:
         return {
             "type": self.type_amino,
@@ -355,6 +450,13 @@ class MsgUpdateContractAdmin(Msg):
                 "new_admin": self.new_admin,
                 "contract": self.contract,
             },
+        }
+
+    def to_data(self) -> dict:
+        return {
+            "admin": self.admin,
+            "new_admin": self.new_admin,
+            "contract": self.contract,
         }
 
     @classmethod
@@ -398,10 +500,24 @@ class MsgClearContractAdmin(Msg):
     admin: AccAddress = attr.ib()
     contract: AccAddress = attr.ib()
 
+    @classmethod
+    def from_amino(cls, amino: dict) -> MsgClearContractAdmin:
+        assert cls.type_amino == amino["type"]
+        return cls(
+            admin=amino["value"]["admin"],
+            contract=amino["value"]["contract"],
+        )
+
     def to_amino(self) -> dict:
         return {
             "type": self.type_amino,
             "value": {"admin": self.admin, "contract": self.contract},
+        }
+
+    def to_data(self) -> dict:
+        return {
+            "admin": self.admin,
+            "contract": self.contract,
         }
 
     @classmethod


### PR DESCRIPTION
fix `from_proto` in MsgExecAuthorized/MsgSetWithdrawAddress/MsgWithdrawValidatorCommission/MsgFundCommunityPool
fix `unpack_any` in MsgMultiSend/MsgVerifyInvariant

Integration test can be found in `from_proto.py`.