### PR TITLE
make parse_msg() won't panic with a non-json string

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,9 @@ jobs:
           python-version: 3.9
 
       - name: Setup Poetry
-        uses: Gr1N/setup-poetry@v4
+        uses: Gr1N/setup-poetry@v7
+        with:
+          poetry-version: 1.2.0
 
       - name: Cache Dependencies
         uses: actions/cache@v2

--- a/integration_tests/decode.py
+++ b/integration_tests/decode.py
@@ -1,0 +1,11 @@
+from terra_sdk.client.lcd import LCDClient
+
+
+def main():
+    terra = LCDClient(
+        url="https://phoenix-lcd.terra.dev",
+        chain_id="phoenix-1",
+    )
+    print(terra.tx.tx_infos_by_height(1763383))
+
+main()

--- a/terra_sdk/core/wasm/data.py
+++ b/terra_sdk/core/wasm/data.py
@@ -14,15 +14,10 @@ from terra_proto.cosmwasm.wasm.v1 import ContractCodeHistoryOperationType
 
 from terra_sdk.core.bech32 import AccAddress
 from terra_sdk.core.msg import Msg
+from terra_sdk.core.wasm.util import parse_msg
 from terra_sdk.util.json import JSONSerializable
 
 __all__ = ["AccessType", "AccessConfig", "AccessConfigUpdate", "AccessTypeParam"]
-
-
-def parse_msg(msg: Union[dict, str, bytes]) -> dict:
-    if type(msg) is dict:
-        return msg
-    return json.loads(msg)
 
 
 def convert_access_type_from_json(access_type: str) -> AccessType:

--- a/terra_sdk/core/wasm/msgs.py
+++ b/terra_sdk/core/wasm/msgs.py
@@ -34,9 +34,10 @@ __all__ = [
 
 
 def parse_msg(msg: Union[dict, str, bytes]) -> dict:
-    if type(msg) is dict:
+    try:
+        return json.loads(msg)
+    except:
         return msg
-    return json.loads(msg)
 
 
 @attr.s

--- a/terra_sdk/core/wasm/msgs.py
+++ b/terra_sdk/core/wasm/msgs.py
@@ -22,6 +22,7 @@ from terra_sdk.core import AccAddress, Coins
 from terra_sdk.core.msg import Msg
 from terra_sdk.core.wasm.data import AccessConfig, AccessTypeParam
 from terra_sdk.util.remove_none import remove_none
+from terra_sdk.core.wasm.util import parse_msg
 
 __all__ = [
     "MsgStoreCode",
@@ -31,13 +32,6 @@ __all__ = [
     "MsgUpdateAdmin",
     "MsgClearAdmin",
 ]
-
-
-def parse_msg(msg: Union[dict, str, bytes]) -> dict:
-    try:
-        return json.loads(msg)
-    except:
-        return msg
 
 
 @attr.s

--- a/terra_sdk/core/wasm/proposals.py
+++ b/terra_sdk/core/wasm/proposals.py
@@ -32,6 +32,7 @@ from terra_proto.cosmwasm.wasm.v1 import (
 from terra_sdk.core.bech32 import AccAddress
 from terra_sdk.core.coins import Coins
 from terra_sdk.core.wasm.data import AccessConfig, AccessConfigUpdate
+from terra_sdk.core.wasm.util import parse_msg
 from terra_sdk.util.json import JSONSerializable
 from terra_sdk.util.remove_none import remove_none
 
@@ -47,12 +48,6 @@ __all__ = [
     "UpdateAdminProposal",
     "UpdateInstantiateConfigProposal",
 ]
-
-
-def parse_msg(msg: Union[dict, str, bytes]) -> dict:
-    if type(msg) is dict:
-        return msg
-    return json.loads(msg)
 
 
 @attr.s

--- a/terra_sdk/core/wasm/util.py
+++ b/terra_sdk/core/wasm/util.py
@@ -1,0 +1,8 @@
+import json
+from typing import Union
+
+def parse_msg(msg: Union[dict, str, bytes]) -> dict:
+    try:
+        return json.loads(msg)
+    except:
+        return msg


### PR DESCRIPTION
to fix tx decode error with non-json msg
- also workflow patch to bump poetry to 1.2.0